### PR TITLE
Per record precision as float

### DIFF
--- a/tests/data/vcf_evaluate/ealuate_vcf.expect.summary_stats.json
+++ b/tests/data/vcf_evaluate/ealuate_vcf.expect.summary_stats.json
@@ -1,0 +1,63 @@
+{
+  "Precision": {
+    "ALL": {
+      "FP": {
+        "Count": 1,
+        "SUM_ALLELE_MATCH_FRAC": 0.0,
+        "SUM_EDIT_DIST": 1
+      },
+      "Precision": 0.90909091,
+      "Precision_frac": 0.90909091,
+      "TP": {
+        "Count": 10,
+        "SUM_ALLELE_MATCH_FRAC": 10.0,
+        "SUM_EDIT_DIST": 10
+      }
+    },
+    "FILT": {
+      "FP": {
+        "Count": 1,
+        "SUM_ALLELE_MATCH_FRAC": 0.0,
+        "SUM_EDIT_DIST": 1
+      },
+      "Precision": 0.9,
+      "Precision_frac": 0.9,
+      "TP": {
+        "Count": 9,
+        "SUM_ALLELE_MATCH_FRAC": 9.0,
+        "SUM_EDIT_DIST": 9
+      }
+    },
+    "UNUSED": 1
+  },
+  "Recall": {
+    "ALL": {
+      "FN": {
+        "Count": 3,
+        "SUM_ALLELE_MATCH_FRAC": 1.0,
+        "SUM_EDIT_DIST": 3
+      },
+      "Recall": 0.76923077,
+      "Recall_frac": 0.84615385,
+      "TP": {
+        "Count": 10,
+        "SUM_ALLELE_MATCH_FRAC": 10.0,
+        "SUM_EDIT_DIST": 10
+      }
+    },
+    "FILT": {
+      "FN": {
+        "Count": 4,
+        "SUM_ALLELE_MATCH_FRAC": 1.0,
+        "SUM_EDIT_DIST": 4
+      },
+      "Recall": 0.69230769,
+      "Recall_frac": 0.76923077,
+      "TP": {
+        "Count": 9,
+        "SUM_ALLELE_MATCH_FRAC": 9.0,
+        "SUM_EDIT_DIST": 9
+      }
+    }
+  }
+}

--- a/tests/data/vcf_evaluate/evaluate_vcf.expect.masked.summary_stats.json
+++ b/tests/data/vcf_evaluate/evaluate_vcf.expect.masked.summary_stats.json
@@ -7,6 +7,7 @@
         "SUM_EDIT_DIST": 1
       },
       "Precision": 0.9,
+      "Precision_frac": 0.9,
       "TP": {
         "Count": 9,
         "SUM_ALLELE_MATCH_FRAC": 9.0,
@@ -20,6 +21,7 @@
         "SUM_EDIT_DIST": 1
       },
       "Precision": 0.88888889,
+      "Precision_frac": 0.88888889,
       "TP": {
         "Count": 8,
         "SUM_ALLELE_MATCH_FRAC": 8.0,
@@ -36,6 +38,7 @@
         "SUM_EDIT_DIST": 3
       },
       "Recall": 0.75,
+      "Recall_frac": 0.83333333,
       "TP": {
         "Count": 9,
         "SUM_ALLELE_MATCH_FRAC": 9.0,
@@ -49,6 +52,7 @@
         "SUM_EDIT_DIST": 4
       },
       "Recall": 0.66666667,
+      "Recall_frac": 0.75,
       "TP": {
         "Count": 8,
         "SUM_ALLELE_MATCH_FRAC": 8.0,

--- a/tests/data/vcf_evaluate/evaluate_vcf.expect.summary_stats.json
+++ b/tests/data/vcf_evaluate/evaluate_vcf.expect.summary_stats.json
@@ -7,6 +7,7 @@
         "SUM_EDIT_DIST": 1
       },
       "Precision": 0.90909091,
+      "Precision_frac": 0.90909091,
       "TP": {
         "Count": 10,
         "SUM_ALLELE_MATCH_FRAC": 10.0,
@@ -20,6 +21,7 @@
         "SUM_EDIT_DIST": 1
       },
       "Precision": 0.9,
+      "Precision_frac": 0.9,
       "TP": {
         "Count": 9,
         "SUM_ALLELE_MATCH_FRAC": 9.0,
@@ -36,6 +38,7 @@
         "SUM_EDIT_DIST": 3
       },
       "Recall": 0.76923077,
+      "Recall_frac": 0.84615385,
       "TP": {
         "Count": 10,
         "SUM_ALLELE_MATCH_FRAC": 10.0,
@@ -49,6 +52,7 @@
         "SUM_EDIT_DIST": 4
       },
       "Recall": 0.69230769,
+      "Recall_frac": 0.76923077,
       "TP": {
         "Count": 9,
         "SUM_ALLELE_MATCH_FRAC": 9.0,

--- a/tests/vcf_evaluate_test.py
+++ b/tests/vcf_evaluate_test.py
@@ -13,12 +13,12 @@ data_dir = os.path.join(this_dir, "data", "vcf_evaluate")
 def test_add_overall_precision_and_recall_to_summary_stats():
     stats = {
         "Precision": {
-            "ALL": {"TP": {"Count": 9}, "FP": {"Count": 1}},
-            "FILT": {"TP": {"Count": 5}, "FP": {"Count": 0}},
+            "ALL": {"TP": {"Count": 9, "SUM_ALLELE_MATCH_FRAC": 9.0}, "FP": {"Count": 1, "SUM_ALLELE_MATCH_FRAC": 0.99}},
+            "FILT": {"TP": {"Count": 5, "SUM_ALLELE_MATCH_FRAC": 5.0}, "FP": {"Count": 0, "SUM_ALLELE_MATCH_FRAC": 0}},
         },
         "Recall": {
-            "ALL": {"TP": {"Count": 4}, "FN": {"Count": 1}},
-            "FILT": {"TP": {"Count": 0}, "FN": {"Count": 0}},
+            "ALL": {"TP": {"Count": 5, "SUM_ALLELE_MATCH_FRAC": 5.0}, "FN": {"Count": 1, "SUM_ALLELE_MATCH_FRAC": 0.2}},
+            "FILT": {"TP": {"Count": 0, "SUM_ALLELE_MATCH_FRAC": 0.0}, "FN": {"Count": 0, "SUM_ALLELE_MATCH_FRAC": 0.0}},
         },
     }
     expect = copy.deepcopy(stats)
@@ -26,8 +26,12 @@ def test_add_overall_precision_and_recall_to_summary_stats():
     assert stats != expect
     expect["Precision"]["ALL"]["Precision"] = 0.9
     expect["Precision"]["FILT"]["Precision"] = 1
-    expect["Recall"]["ALL"]["Recall"] = 0.8
+    expect["Recall"]["ALL"]["Recall"] = 0.83333333
     expect["Recall"]["FILT"]["Recall"] = 0
+    expect["Precision"]["ALL"]["Precision_frac"] = 0.999
+    expect["Precision"]["FILT"]["Precision_frac"] = 1.0
+    expect["Recall"]["ALL"]["Recall_frac"] = 0.86666667
+    expect["Recall"]["FILT"]["Recall_frac"] = 0
     assert stats == expect
 
 

--- a/varifier/vcf_evaluate.py
+++ b/varifier/vcf_evaluate.py
@@ -15,12 +15,15 @@ def _add_overall_precision_and_recall_to_summary_stats(summary_stats):
         for all_or_filt in "ALL", "FILT":
             d = summary_stats[prec_or_recall][all_or_filt]
             tp = d["TP"]["Count"]
+            tp_frac = d["TP"]["SUM_ALLELE_MATCH_FRAC"] + d[fp_key]["SUM_ALLELE_MATCH_FRAC"]
             fp = d[fp_key]["Count"]
             total_calls = tp + fp
             if total_calls > 0:
                 d[prec_or_recall] = round(tp / total_calls, 8)
+                d[f"{prec_or_recall}_frac"] = round(tp_frac / total_calls, 8)
             else:
                 d[prec_or_recall] = 0
+                d[f"{prec_or_recall}_frac"] = 0
 
 
 def evaluate_vcf(


### PR DESCRIPTION
Adds new results to the final summary json: Precision_frac and Recall_frac, where instead of just counting TPs and FPs, count the fraction of each allele that was called correctly. This means incorrect calls that call part of the allele correctly contribute positively to precision recall by getting a number in (0,1) instead of zero.