### PR TITLE
Add --truth_vcf option

### DIFF
--- a/tests/recall_test.py
+++ b/tests/recall_test.py
@@ -56,7 +56,7 @@ def test_get_recall():
     tmp_out = "tmp.get_recall"
     subprocess.check_output(f"rm -rf {tmp_out}", shell=True)
     got_vcf_all, got_vcf_filtered = recall.get_recall(
-        ref_fasta, vcf_to_test, truth_fasta, tmp_out, debug=True
+        ref_fasta, vcf_to_test, tmp_out, debug=True, truth_fasta=truth_fasta,
     )
     expect_vcf_all = os.path.join(data_dir, "get_recall.expect.all.vcf")
     assert utils.vcf_records_are_the_same(got_vcf_all, expect_vcf_all)

--- a/varifier/__main__.py
+++ b/varifier/__main__.py
@@ -59,11 +59,18 @@ def main(args=None):
         "--force", help="Replace outdir if it already exists", action="store_true"
     )
     subparser_vcf_eval.add_argument(
-        "--mask", help="BED file of regions to mask. Any variants in the VCF overlapping the mask are removed at the start of the pipeline",
+        "--mask",
+        help="BED file of regions to mask. Any variants in the VCF overlapping the mask are removed at the start of the pipeline",
         metavar="FILENAME",
     )
     subparser_vcf_eval.add_argument(
-        "--use_ref_calls", help="Include 0/0 genotype calls when calculating TPs and precision. By default they are ignored",
+        "--truth_vcf",
+        help="VCF file of variant calls between vcf_fasta and truth_fasta, where reference of this VCF file is truth_fasta. If provided, used to calculate recall",
+        metavar="FILENAME",
+    )
+    subparser_vcf_eval.add_argument(
+        "--use_ref_calls",
+        help="Include 0/0 genotype calls when calculating TPs and precision. By default they are ignored",
         action="store_true",
     )
     subparser_vcf_eval.add_argument("truth_fasta", help="FASTA file of truth genome")

--- a/varifier/recall.py
+++ b/varifier/recall.py
@@ -53,17 +53,23 @@ def apply_variants_to_genome(ref_fasta, vcf_file, out_fasta, pass_only=True):
             print(new_seq, file=f)
 
 
-def get_recall(ref_fasta, vcf_to_test, truth_fasta, outdir, debug=False):
+def get_recall(
+    ref_fasta, vcf_to_test, outdir, truth_fasta=None, truth_vcf=None, debug=False
+):
     os.mkdir(outdir)
 
-    # Make truth VCF. This only depends on ref_fasta and truth_fasta, not
-    # on VCF to test. In particular, is independent of whether or not
-    # were using all records in vcf_to_test, or PASS records only. This means
-    # only need to make one truth VCF, which can be used for both cases.
-    truth_outdir = os.path.join(outdir, "truth_vcf")
-    truth_vcf = truth_variant_finding.make_truth_vcf(
-        ref_fasta, truth_fasta, truth_outdir, debug=debug
-    )
+    if truth_vcf is None:
+        assert truth_fasta is not None
+        # Make truth VCF. This only depends on ref_fasta and truth_fasta, not
+        # on VCF to test. In particular, is independent of whether or not
+        # were using all records in vcf_to_test, or PASS records only. This means
+        # only need to make one truth VCF, which can be used for both cases.
+        truth_outdir = os.path.join(outdir, "truth_vcf")
+        truth_vcf = truth_variant_finding.make_truth_vcf(
+            ref_fasta, truth_fasta, truth_outdir, debug=debug
+        )
+    else:
+        assert truth_fasta is None
 
     vcfs_out = {}
     for all_or_filt in "ALL", "FILT":

--- a/varifier/tasks/vcf_eval.py
+++ b/varifier/tasks/vcf_eval.py
@@ -8,6 +8,7 @@ def run(options):
         options.truth_fasta,
         options.flank_length,
         options.outdir,
+        truth_vcf=options.truth_vcf,
         debug=options.debug,
         force=options.force,
         mask_bed_file=options.mask,

--- a/varifier/vcf_evaluate.py
+++ b/varifier/vcf_evaluate.py
@@ -15,7 +15,9 @@ def _add_overall_precision_and_recall_to_summary_stats(summary_stats):
         for all_or_filt in "ALL", "FILT":
             d = summary_stats[prec_or_recall][all_or_filt]
             tp = d["TP"]["Count"]
-            tp_frac = d["TP"]["SUM_ALLELE_MATCH_FRAC"] + d[fp_key]["SUM_ALLELE_MATCH_FRAC"]
+            tp_frac = (
+                d["TP"]["SUM_ALLELE_MATCH_FRAC"] + d[fp_key]["SUM_ALLELE_MATCH_FRAC"]
+            )
             fp = d[fp_key]["Count"]
             total_calls = tp + fp
             if total_calls > 0:
@@ -32,6 +34,7 @@ def evaluate_vcf(
     truth_ref_fasta,
     flank_length,
     outdir,
+    truth_vcf=None,
     debug=False,
     force=False,
     mask_bed_file=None,
@@ -64,15 +67,25 @@ def evaluate_vcf(
         discard_ref_calls=discard_ref_calls,
     )
 
-    # Make truth VCF annotated with TP/FP for recall
     recall_dir = os.path.join(outdir, "recall")
     vcf_for_recall_all, vcf_for_recall_filtered = recall.get_recall(
-        vcf_ref_fasta, vcf_to_eval, truth_ref_fasta, recall_dir, debug=debug
+        vcf_ref_fasta,
+        vcf_to_eval,
+        recall_dir,
+        debug=debug,
+        truth_fasta=truth_ref_fasta if truth_vcf is None else None,
+        truth_vcf=truth_vcf,
     )
     if mask_bed_file is not None:
-        utils.mask_vcf_file(vcf_for_recall_all, mask_bed_file, f"{vcf_for_recall_all}.masked.vcf")
+        utils.mask_vcf_file(
+            vcf_for_recall_all, mask_bed_file, f"{vcf_for_recall_all}.masked.vcf"
+        )
         vcf_for_recall_all = f"{vcf_for_recall_all}.masked.vcf"
-        utils.mask_vcf_file(vcf_for_recall_filtered, mask_bed_file, f"{vcf_for_recall_filtered}.masked.vcf")
+        utils.mask_vcf_file(
+            vcf_for_recall_filtered,
+            mask_bed_file,
+            f"{vcf_for_recall_filtered}.masked.vcf",
+        )
         vcf_for_recall_filtered = f"{vcf_for_recall_filtered}.masked.vcf"
         os.unlink(masked_vcf)
 


### PR DESCRIPTION
Adds option for user to provide a truth VCF. If given, then uses it instead of inferring the truth VCF by aligning the ref and truth genomes.