### PR TITLE
Handle asterisk ALTs properly

### DIFF
--- a/tests/data/utils/read_vcf_file.vcf
+++ b/tests/data/utils/read_vcf_file.vcf
@@ -7,3 +7,5 @@ ref	45	4	.	A	.	PASS	.	GT	1/1
 ref	46	5	T	A	.	MISMAPPED_UNPLACEABLE	.	GT	1/1
 ref	47	6	T	A	.	PASS	.	GT	0/1
 ref	48	7	T	A	.	PASS	.	GT	0/0
+ref	49	8	T	A,*	.	PASS	.	GT	1/1
+ref	50	9	T	A,*	.	PASS	.	GT	2/2

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -42,6 +42,11 @@ def test_read_vcf_file():
             vcf_record.VcfRecord("ref\t48\t7\tT\tA\t.\tPASS\t.\tGT\t0/0"),
             "CANNOT_USE_GT",
         ),
+        (vcf_record.VcfRecord("ref\t49\t8\tT\tA,*\t.\tPASS\t.\tGT\t1/1"), "PASS",),
+        (
+            vcf_record.VcfRecord("ref\t50\t9\tT\tA,*\t.\tPASS\t.\tGT\t2/2"),
+            "CANNOT_USE_GT",
+        ),
     ]
 
     assert header_lines == expect_header


### PR DESCRIPTION
Fix to handle where alt has an asterisk, eg `A,*`. Count as unable to evaluate if the genotype is the `*`, otherwise we can evaluate the record.