### PR TITLE
Logging formatting and fix header ID

### DIFF
--- a/tests/data/probe_mapping/annotate_vcf_with_probe_mapping.expect.rev.vcf
+++ b/tests/data/probe_mapping/annotate_vcf_with_probe_mapping.expect.rev.vcf
@@ -8,6 +8,7 @@
 ##FORMAT=<ID=VFR_ED_RA,Number=1,Type=String,Description="Edit distance between ref and alt allele (using the called allele where more than one alt)">
 ##FORMAT=<ID=VFR_ED_TR,Number=1,Type=String,Description="Edit distance between truth and ref allele">
 ##FORMAT=<ID=VFR_ED_TA,Number=1,Type=String,Description="Edit distance between truth and alt allele">
+##FORMAT=<ID=VFR_ED_SCORE,Number=1,Type=String,Description="Edit distance score">
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample
 ref	37	1	T	A	.	PASS	.	GT:EXPECT:VFR_FILTER:VFR_ED_RA:VFR_ED_TR:VFR_ED_TA:VFR_ALLELE_LEN:VFR_ALLELE_MATCH_COUNT:VFR_ALLELE_MATCH_FRAC:VFR_IN_MASK:VFR_RESULT	1/1:FP:FAIL_CONFLICT:1:0:1:1:0:0.0:0:FP
 ref	37	2	T	C	.	PASS	.	GT:EXPECT:VFR_FILTER:VFR_ED_RA:VFR_ED_TR:VFR_ED_TA:VFR_ALLELE_LEN:VFR_ALLELE_MATCH_COUNT:VFR_ALLELE_MATCH_FRAC:VFR_IN_MASK:VFR_RESULT	1/1:FP:FAIL_CONFLICT:1:0:1:1:0:0.0:0:FP

--- a/tests/data/probe_mapping/annotate_vcf_with_probe_mapping.expect.rev.vcf
+++ b/tests/data/probe_mapping/annotate_vcf_with_probe_mapping.expect.rev.vcf
@@ -1,6 +1,6 @@
 ##contig=<ID=ref,length=430>
 ##FORMAT=<ID=VFR_FILTER,Number=1,Type=String,Description="Initial filtering of VCF record. If PASS, then it is evaluated, otherwise is skipped">
-##FORMAT=<ID=IN_MASK,Number=1,Type=String,Description="Whether or not the variant is in the truth genome mask">
+##FORMAT=<ID=VFR_IN_MASK,Number=1,Type=String,Description="Whether or not the variant is in the truth genome mask">
 ##FORMAT=<ID=VFR_RESULT,Number=1,Type=String,Description="FP, TP, or Partial_TP when part of the allele matches the truth reference">
 ##FORMAT=<ID=VFR_ALLELE_LEN,Number=1,Type=Integer,Description="Number of positions in allele that were checked if they match the truth">
 ##FORMAT=<ID=VFR_ALLELE_MATCH_COUNT,Number=1,Type=String,Description="Number of positions in allele that match the truth">

--- a/tests/data/probe_mapping/annotate_vcf_with_probe_mapping.expect.vcf
+++ b/tests/data/probe_mapping/annotate_vcf_with_probe_mapping.expect.vcf
@@ -8,6 +8,7 @@
 ##FORMAT=<ID=VFR_ED_RA,Number=1,Type=String,Description="Edit distance between ref and alt allele (using the called allele where more than one alt)">
 ##FORMAT=<ID=VFR_ED_TR,Number=1,Type=String,Description="Edit distance between truth and ref allele">
 ##FORMAT=<ID=VFR_ED_TA,Number=1,Type=String,Description="Edit distance between truth and alt allele">
+##FORMAT=<ID=VFR_ED_SCORE,Number=1,Type=String,Description="Edit distance score">
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample
 ref	37	1	T	A	.	PASS	.	GT:EXPECT:VFR_FILTER:VFR_ED_RA:VFR_ED_TR:VFR_ED_TA:VFR_ALLELE_LEN:VFR_ALLELE_MATCH_COUNT:VFR_ALLELE_MATCH_FRAC:VFR_IN_MASK:VFR_RESULT	1/1:FP:FAIL_CONFLICT:1:0:1:1:0:0.0:0:FP
 ref	37	2	T	C	.	PASS	.	GT:EXPECT:VFR_FILTER:VFR_ED_RA:VFR_ED_TR:VFR_ED_TA:VFR_ALLELE_LEN:VFR_ALLELE_MATCH_COUNT:VFR_ALLELE_MATCH_FRAC:VFR_IN_MASK:VFR_RESULT	1/1:FP:FAIL_CONFLICT:1:0:1:1:0:0.0:0:FP

--- a/tests/data/probe_mapping/annotate_vcf_with_probe_mapping.expect.vcf
+++ b/tests/data/probe_mapping/annotate_vcf_with_probe_mapping.expect.vcf
@@ -1,6 +1,6 @@
 ##contig=<ID=ref,length=430>
 ##FORMAT=<ID=VFR_FILTER,Number=1,Type=String,Description="Initial filtering of VCF record. If PASS, then it is evaluated, otherwise is skipped">
-##FORMAT=<ID=IN_MASK,Number=1,Type=String,Description="Whether or not the variant is in the truth genome mask">
+##FORMAT=<ID=VFR_IN_MASK,Number=1,Type=String,Description="Whether or not the variant is in the truth genome mask">
 ##FORMAT=<ID=VFR_RESULT,Number=1,Type=String,Description="FP, TP, or Partial_TP when part of the allele matches the truth reference">
 ##FORMAT=<ID=VFR_ALLELE_LEN,Number=1,Type=Integer,Description="Number of positions in allele that were checked if they match the truth">
 ##FORMAT=<ID=VFR_ALLELE_MATCH_COUNT,Number=1,Type=String,Description="Number of positions in allele that match the truth">

--- a/varifier/__main__.py
+++ b/varifier/__main__.py
@@ -112,11 +112,10 @@ def main(args=None):
 
     args = parser.parse_args()
 
-    log = logging.getLogger()
-    if args.debug:
-        log.setLevel(logging.DEBUG)
-    else:
-        log.setLevel(logging.INFO)
+    log_level = logging.DEBUG if args.debug else logging.INFO
+    logging.basicConfig(
+        format="%(asctime)s [%(levelname)s]: %(message)s", level=log_level
+    )
 
     if hasattr(args, "func"):
         args.func(args)

--- a/varifier/probe_mapping.py
+++ b/varifier/probe_mapping.py
@@ -259,7 +259,7 @@ def annotate_vcf_with_probe_mapping(
         f_map = None
 
     new_header_lines = [
-        '##FORMAT=<ID=IN_MASK,Number=1,Type=String,Description="Whether or not the variant is in the truth genome mask">',
+        '##FORMAT=<ID=VFR_IN_MASK,Number=1,Type=String,Description="Whether or not the variant is in the truth genome mask">',
         '##FORMAT=<ID=VFR_RESULT,Number=1,Type=String,Description="FP, TP, or Partial_TP when part of the allele matches the truth reference">',
         '##FORMAT=<ID=VFR_ALLELE_LEN,Number=1,Type=Integer,Description="Number of positions in allele that were checked if they match the truth">',
         '##FORMAT=<ID=VFR_ALLELE_MATCH_COUNT,Number=1,Type=String,Description="Number of positions in allele that match the truth">',

--- a/varifier/probe_mapping.py
+++ b/varifier/probe_mapping.py
@@ -267,6 +267,7 @@ def annotate_vcf_with_probe_mapping(
         '##FORMAT=<ID=VFR_ED_RA,Number=1,Type=String,Description="Edit distance between ref and alt allele (using the called allele where more than one alt)">',
         '##FORMAT=<ID=VFR_ED_TR,Number=1,Type=String,Description="Edit distance between truth and ref allele">',
         '##FORMAT=<ID=VFR_ED_TA,Number=1,Type=String,Description="Edit distance between truth and alt allele">',
+        '##FORMAT=<ID=VFR_ED_SCORE,Number=1,Type=String,Description="Edit distance score">',
     ]
 
     with open(vcf_out, "w") as f_vcf:


### PR DESCRIPTION
This PR provides a little more logging as to what part of the vcf eval routine the code is currently on (and formats it a little nicer).

## Fixes

- ID for the `VFR_IN_MASK` which was incorrectly being written as `IN_MASK`
- ID for `VFR_ED_SCORE` was not in the header