### PR TITLE
handle asterisk in non-called alleles

### DIFF
--- a/tests/data/vcf_evaluate/filter_vcf.expect.no_filter_pass_exclude_ref_calls.exclude.vcf
+++ b/tests/data/vcf_evaluate/filter_vcf.expect.no_filter_pass_exclude_ref_calls.exclude.vcf
@@ -9,5 +9,5 @@ ref	5	.	A	.	.	PASS	.	GT:NOTES:VFR_EXCLUDE_REASON	1:Should always get removed bec
 ref	6	.	T	C	.	PASS	.	NOTES:VFR_EXCLUDE_REASON	Should always get removed because no GT:no_genotype
 ref	7	.	.	A	.	PASS	.	GT:NOTES:VFR_EXCLUDE_REASON	1:Should always get removed because REF is .:other
 ref	8	.	A	T	.	PASS	.	GT:NOTES:VFR_EXCLUDE_REASON	0/1:Should always get removed because heterozygous:heterozygous
-ref	12	.	C	N	.	PASS	.	GT:NOTES:VFR_EXCLUDE_REASON	1/1:Should always get removed because N in alt:non_acgt
+ref	12	.	C	N,T	.	PASS	.	GT:NOTES:VFR_EXCLUDE_REASON	1/1:Should always get removed because N in genotyped alt:non_acgt
 ref	13	.	ANNN	A	.	PASS	.	GT:NOTES:VFR_EXCLUDE_REASON	1/1:Should always get removed because N in ref:non_acgt

--- a/tests/data/vcf_evaluate/filter_vcf.expect.no_filter_pass_keep_ref_calls.keep.vcf
+++ b/tests/data/vcf_evaluate/filter_vcf.expect.no_filter_pass_keep_ref_calls.keep.vcf
@@ -8,3 +8,4 @@ ref	2	.	T	G	.	PASS	.	GT:NOTES	1:Good alt call
 ref	9	.	C	G	.	.	.	GT:NOTES	1/1:Removal depends on filter_pass option
 ref	10	.	T	G	.	FILTER_1	.	GT:NOTES	1/1:Removal depends on filter_pass option
 ref	11	.	G	G	.	FILTER_1;FILTER_2	.	GT:NOTES	1/1:Removal depends on filter_pass option
+ref	17	.	C	A,*	.	PASS	.	GT:NOTES	1/1:Should not get removed because called allele ok

--- a/tests/data/vcf_evaluate/filter_vcf.expect.with_filtering.1.exclude.vcf
+++ b/tests/data/vcf_evaluate/filter_vcf.expect.with_filtering.1.exclude.vcf
@@ -13,5 +13,5 @@ ref	8	.	A	T	.	PASS	.	GT:NOTES:VFR_EXCLUDE_REASON	0/1:Should always get removed b
 ref	9	.	C	G	.	.	.	GT:NOTES:VFR_EXCLUDE_REASON	1/1:Removal depends on filter_pass option:filter_fail
 ref	10	.	T	G	.	FILTER_1	.	GT:NOTES:VFR_EXCLUDE_REASON	1/1:Removal depends on filter_pass option:filter_fail
 ref	11	.	G	G	.	FILTER_1;FILTER_2	.	GT:NOTES:VFR_EXCLUDE_REASON	1/1:Removal depends on filter_pass option:filter_fail
-ref	12	.	C	N	.	PASS	.	GT:NOTES:VFR_EXCLUDE_REASON	1/1:Should always get removed because N in alt:non_acgt
+ref	12	.	C	N,T	.	PASS	.	GT:NOTES:VFR_EXCLUDE_REASON	1/1:Should always get removed because N in genotyped alt:non_acgt
 ref	13	.	ANNN	A	.	PASS	.	GT:NOTES:VFR_EXCLUDE_REASON	1/1:Should always get removed because N in ref:non_acgt

--- a/tests/data/vcf_evaluate/filter_vcf.expect.with_filtering.1.keep.vcf
+++ b/tests/data/vcf_evaluate/filter_vcf.expect.with_filtering.1.keep.vcf
@@ -4,3 +4,4 @@
 ##FORMAT=<ID=NOTES,Number=1,Type=String,Description="Notes for what we expect the test to do with the record">
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample
 ref	2	.	T	G	.	PASS	.	GT:NOTES	1:Good alt call
+ref	17	.	C	A,*	.	PASS	.	GT:NOTES	1/1:Should not get removed because called allele ok

--- a/tests/data/vcf_evaluate/filter_vcf.expect.with_filtering.2.exclude.vcf
+++ b/tests/data/vcf_evaluate/filter_vcf.expect.with_filtering.2.exclude.vcf
@@ -11,5 +11,5 @@ ref	6	.	T	C	.	PASS	.	NOTES:VFR_EXCLUDE_REASON	Should always get removed because 
 ref	7	.	.	A	.	PASS	.	GT:NOTES:VFR_EXCLUDE_REASON	1:Should always get removed because REF is .:other
 ref	8	.	A	T	.	PASS	.	GT:NOTES:VFR_EXCLUDE_REASON	0/1:Should always get removed because heterozygous:heterozygous
 ref	10	.	T	G	.	FILTER_1	.	GT:NOTES:VFR_EXCLUDE_REASON	1/1:Removal depends on filter_pass option:filter_fail
-ref	12	.	C	N	.	PASS	.	GT:NOTES:VFR_EXCLUDE_REASON	1/1:Should always get removed because N in alt:non_acgt
+ref	12	.	C	N,T	.	PASS	.	GT:NOTES:VFR_EXCLUDE_REASON	1/1:Should always get removed because N in genotyped alt:non_acgt
 ref	13	.	ANNN	A	.	PASS	.	GT:NOTES:VFR_EXCLUDE_REASON	1/1:Should always get removed because N in ref:non_acgt

--- a/tests/data/vcf_evaluate/filter_vcf.expect.with_filtering.2.keep.vcf
+++ b/tests/data/vcf_evaluate/filter_vcf.expect.with_filtering.2.keep.vcf
@@ -6,3 +6,4 @@
 ref	2	.	T	G	.	PASS	.	GT:NOTES	1:Good alt call
 ref	9	.	C	G	.	.	.	GT:NOTES	1/1:Removal depends on filter_pass option
 ref	11	.	G	G	.	FILTER_1;FILTER_2	.	GT:NOTES	1/1:Removal depends on filter_pass option
+ref	17	.	C	A,*	.	PASS	.	GT:NOTES	1/1:Should not get removed because called allele ok

--- a/tests/data/vcf_evaluate/filter_vcf.in.vcf
+++ b/tests/data/vcf_evaluate/filter_vcf.in.vcf
@@ -14,5 +14,6 @@ ref	8	.	A	T	.	PASS	.	GT:NOTES	0/1:Should always get removed because heterozygous
 ref	9	.	C	G	.	.	.	GT:NOTES	1/1:Removal depends on filter_pass option
 ref	10	.	T	G	.	FILTER_1	.	GT:NOTES	1/1:Removal depends on filter_pass option
 ref	11	.	G	G	.	FILTER_1;FILTER_2	.	GT:NOTES	1/1:Removal depends on filter_pass option
-ref	12	.	C	N	.	PASS	.	GT:NOTES	1/1:Should always get removed because N in alt
+ref	12	.	C	N,T	.	PASS	.	GT:NOTES	1/1:Should always get removed because N in genotyped alt
 ref	13	.	ANNN	A	.	PASS	.	GT:NOTES	1/1:Should always get removed because N in ref
+ref	17	.	C	A,*	.	PASS	.	GT:NOTES	1/1:Should not get removed because called allele ok

--- a/varifier/utils.py
+++ b/varifier/utils.py
@@ -16,6 +16,23 @@ def vcf_record_is_all_acgt(record):
     return True
 
 
+def vcf_record_has_non_acgt_ref(record):
+    return all_acgt_regex.search(record.REF) is None
+
+
+def genotyped_hom_vcf_record_has_non_acgt_call(record):
+    """Assumes the record has GT in the FORMAT, ie has been genotyped,
+    and also the genotype is one allele so homozygous, not het.
+    returns True if the called allele is ACGT characters only"""
+    gt = set(record.FORMAT.get("GT", ".").split("/"))
+    assert len(gt) == 1
+    gt = int(gt.pop())
+    if gt == 0:
+        return all_acgt_regex.search(record.REF) is None
+    else:
+        return all_acgt_regex.search(record.ALT[gt-1]) is None
+
+
 def load_mask_bed_file(mask_bed_file):
     """Loads a BED file of ref seq names, and start and end postiions.
     Returns a dictionary of ref seq name -> set of (0-based) coords in the mask."""

--- a/varifier/vcf_evaluate.py
+++ b/varifier/vcf_evaluate.py
@@ -81,7 +81,7 @@ def _filter_vcf(
                 exclude_reason = "filter_fail"
             elif len(record.ALT) == 0 or record.ALT == ["."]:
                 exclude_reason = "other"
-            elif not utils.vcf_record_is_all_acgt(record):
+            elif utils.vcf_record_has_non_acgt_ref(record):
                 exclude_reason = "non_acgt"
             elif record.FORMAT is None:
                 exclude_reason = "no_genotype"
@@ -101,6 +101,8 @@ def _filter_vcf(
                     exclude_reason = "no_genotype"
                 elif not keep_ref_calls and "0" in gt:
                     exclude_reason = "ref_call"
+                elif utils.genotyped_hom_vcf_record_has_non_acgt_call(record):
+                    exclude_reason = "non_acgt"
                 else:
                     print(record, file=f_out_keep)
 


### PR DESCRIPTION
This fixes case where in the input VCF, one of the ALT alleles has `*`, but the genotyped allele is not `*`. Previously these records were being excluded up front.