### PR TITLE
Add options --global_align_min_coord, --global_align_max_coord

### DIFF
--- a/tests/data/global_align/vcf_using_global_alignment.1-100.vcf
+++ b/tests/data/global_align/vcf_using_global_alignment.1-100.vcf
@@ -1,0 +1,9 @@
+##fileformat=VCFv4.2
+##FILTER=<ID=PASS,Description="All filters passed">
+##contig=<ID=ref,length=100>
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample
+ref	2	0	GC	G	.	PASS	.	GT	1/1
+ref	10	1	G	C	.	PASS	.	GT	1/1
+ref	48	2	T	TC	.	PASS	.	GT	1/1
+ref	100	3	G	GGGT	.	PASS	.	GT	1/1

--- a/tests/data/global_align/vcf_using_global_alignment.2-99.vcf
+++ b/tests/data/global_align/vcf_using_global_alignment.2-99.vcf
@@ -1,0 +1,8 @@
+##fileformat=VCFv4.2
+##FILTER=<ID=PASS,Description="All filters passed">
+##contig=<ID=ref,length=100>
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample
+ref	2	0	GC	G	.	PASS	.	GT	1/1
+ref	10	1	G	C	.	PASS	.	GT	1/1
+ref	48	2	T	TC	.	PASS	.	GT	1/1

--- a/tests/data/global_align/vcf_using_global_alignment.3-98.vcf
+++ b/tests/data/global_align/vcf_using_global_alignment.3-98.vcf
@@ -1,0 +1,7 @@
+##fileformat=VCFv4.2
+##FILTER=<ID=PASS,Description="All filters passed">
+##contig=<ID=ref,length=100>
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample
+ref	10	1	G	C	.	PASS	.	GT	1/1
+ref	48	2	T	TC	.	PASS	.	GT	1/1

--- a/tests/global_align_test.py
+++ b/tests/global_align_test.py
@@ -148,3 +148,24 @@ def test_vcf_using_global_alignment():
     global_align.vcf_using_global_alignment(ref_fasta, qry_fasta, vcf_out)
     assert utils.vcf_records_are_the_same(vcf_out, expect_vcf)
     os.unlink(vcf_out)
+
+    expect_vcf = os.path.join(data_dir, "vcf_using_global_alignment.1-100.vcf")
+    global_align.vcf_using_global_alignment(
+        ref_fasta, qry_fasta, vcf_out, min_ref_coord=0, max_ref_coord=99
+    )
+    assert utils.vcf_records_are_the_same(vcf_out, expect_vcf)
+    os.unlink(vcf_out)
+
+    expect_vcf = os.path.join(data_dir, "vcf_using_global_alignment.2-99.vcf")
+    global_align.vcf_using_global_alignment(
+        ref_fasta, qry_fasta, vcf_out, min_ref_coord=1, max_ref_coord=98
+    )
+    assert utils.vcf_records_are_the_same(vcf_out, expect_vcf)
+    os.unlink(vcf_out)
+
+    expect_vcf = os.path.join(data_dir, "vcf_using_global_alignment.3-98.vcf")
+    global_align.vcf_using_global_alignment(
+        ref_fasta, qry_fasta, vcf_out, min_ref_coord=2, max_ref_coord=97
+    )
+    assert utils.vcf_records_are_the_same(vcf_out, expect_vcf)
+    os.unlink(vcf_out)

--- a/tests/tasks_test.py
+++ b/tests/tasks_test.py
@@ -22,6 +22,8 @@ def test_make_truth_vcf():
     options.cpus = 1
     options.no_maxmatch = False
     options.global_align = False
+    options.global_align_min_coord = 0
+    options.global_align_max_coord = float("inf")
     subprocess.check_output(f"rm -rf {options.outdir}", shell=True)
     tasks.make_truth_vcf.run(options)
     got_vcf = os.path.join(options.outdir, "04.truth.vcf")

--- a/varifier/__main__.py
+++ b/varifier/__main__.py
@@ -76,6 +76,20 @@ def main(args=None):
         help="Only use this with small genomes (ie virus) that have one sequence each, in the same orientation. Instead of using minimap2/nucmer to find variants, do a global alignment for greater accuracy",
         action="store_true",
     )
+    subparser_make_truth_vcf.add_argument(
+        "--global_align_min_coord",
+        help="Only used if also using --global_align. Do not output variants where the REF allele starts before the given (1-based) coordinate [%(default)s]",
+        type=int,
+        metavar="INT",
+        default=1,
+    )
+    subparser_make_truth_vcf.add_argument(
+        "--global_align_max_coord",
+        help="Only used if also using --global_align. Do not output variants where the REF allele ends after the given (1-based) coordinate [infinity]",
+        type=int,
+        metavar="INT",
+        default=float("inf"),
+    )
 
     subparser_make_truth_vcf.add_argument("outdir", help="Name of output directory")
     subparser_make_truth_vcf.set_defaults(func=varifier.tasks.make_truth_vcf.run)

--- a/varifier/global_align.py
+++ b/varifier/global_align.py
@@ -204,7 +204,14 @@ def expand_combined_snps(variants_in):
     return variants_out
 
 
-def vcf_using_global_alignment(ref_fasta, query_fasta, vcf_out, debug=False):
+def vcf_using_global_alignment(
+    ref_fasta,
+    query_fasta,
+    vcf_out,
+    debug=False,
+    min_ref_coord=0,
+    max_ref_coord=float("inf"),
+):
     ref_aln, qry_aln = global_align(
         ref_fasta, query_fasta, f"{vcf_out}.tmp.nucmer", debug=debug
     )
@@ -232,6 +239,9 @@ def vcf_using_global_alignment(ref_fasta, query_fasta, vcf_out, debug=False):
             file=f,
         )
         for i, variant in enumerate(variants):
+            end_coord = variant["ref_start"] + len(variant["ref_allele"]) - 1
+            if min_ref_coord > variant["ref_start"] or end_coord > max_ref_coord:
+                continue
             print(
                 ref_name,
                 variant["ref_start"] + 1,

--- a/varifier/tasks/make_truth_vcf.py
+++ b/varifier/tasks/make_truth_vcf.py
@@ -19,4 +19,6 @@ def run(options):
         threads=options.cpus,
         maxmatch=not options.no_maxmatch,
         use_global_align=options.global_align,
+        global_align_min_coord=options.global_align_min_coord - 1,
+        global_align_max_coord=options.global_align_max_coord - 1,
     )

--- a/varifier/truth_variant_finding.py
+++ b/varifier/truth_variant_finding.py
@@ -147,6 +147,8 @@ def make_truth_vcf(
     threads=1,
     maxmatch=True,
     use_global_align=False,
+    global_align_min_coord=0,
+    global_align_max_coord=float("inf"),
 ):
     _check_dependencies_in_path()
     os.mkdir(outdir)
@@ -163,7 +165,12 @@ def make_truth_vcf(
 
     if use_global_align:
         global_align.vcf_using_global_alignment(
-            ref_fasta, truth_fasta, merged_vcf, debug=debug
+            ref_fasta,
+            truth_fasta,
+            merged_vcf,
+            debug=debug,
+            min_ref_coord=global_align_min_coord,
+            max_ref_coord=global_align_max_coord,
         )
         logging.info(
             f"Made VCF file of variants '{merged_vcf}' by globally aligning ref/truth sequences"


### PR DESCRIPTION
Options to ignore any variants in the start/end of the genome when doing a global alignment. The intended use case is covid genomes, where the amplicons do not cover the entire genome, so we want to exclude the start/end. Otherwise we'll always get the start and end called as deleted in the VCF.