### PR TITLE
Only check minimap2 found if using global align

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,7 +6,6 @@ on:
       - 'v*.*.*'
     branches:
       - master
-      - paftools_optional
   pull_request:
     branches:
       - master

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,89 @@
+name: Build varifier images
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-20.04
+    steps:
+
+    - name: Set up Go 1.16
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.16
+      id: go
+
+    - name: Install Dependencies
+      run: |
+        sudo apt-get update && sudo apt-get install -y \
+          build-essential \
+          libssl-dev \
+          uuid-dev \
+          libgpgme11-dev \
+          squashfs-tools \
+          libseccomp-dev \
+          pkg-config \
+          debootstrap \
+          debian-keyring \
+          debian-archive-keyring \
+          rsync
+
+    - name: Install Singularity
+      env:
+        SINGULARITY_VERSION: 3.5.3
+        GOPATH: /tmp/go
+      run: |
+        mkdir -p $GOPATH
+        sudo mkdir -p /usr/local/var/singularity/mnt
+        mkdir -p $GOPATH/src/github.com/sylabs
+        cd $GOPATH/src/github.com/sylabs
+        wget https://github.com/hpcng/singularity/releases/download/v${SINGULARITY_VERSION}/singularity-${SINGULARITY_VERSION}.tar.gz
+        tar -xzf singularity-${SINGULARITY_VERSION}.tar.gz
+        cd singularity
+        ./mconfig -v -p /usr/local
+        make -j `nproc 2>/dev/null || echo 1` -C ./builddir all
+        sudo make -C ./builddir install
+
+
+    - name: Check out code for the container build
+      uses: actions/checkout@v2
+
+    - name: Set release version if is a release
+      if: startsWith(github.event.ref, 'refs/tags/v')
+      run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+    - name: Set release version if not a release
+      if: false == startsWith(github.event.ref, 'refs/tags/v')
+      run: echo "RELEASE_VERSION=test" >> $GITHUB_ENV
+
+    - name: Build Singularity container
+      env:
+        SINGULARITY_RECIPE: Singularity.def
+        OUTPUT_CONTAINER: varifier_${{env.RELEASE_VERSION}}.img
+      run: |
+        ls
+        if [ -f "${SINGULARITY_RECIPE}" ]; then
+            sudo -E singularity build ${OUTPUT_CONTAINER} ${SINGULARITY_RECIPE}
+        else
+            echo "${SINGULARITY_RECIPE} is not found."
+            echo "Present working directory: $PWD"
+            ls
+        fi
+
+    - name: Release
+      if: startsWith(github.event.ref, 'refs/tags/v')
+      uses: softprops/action-gh-release@v1
+      with:
+        files: varifier*.img
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,6 +6,7 @@ on:
       - 'v*.*.*'
     branches:
       - master
+      - paftools_optional
   pull_request:
     branches:
       - master

--- a/varifier/truth_variant_finding.py
+++ b/varifier/truth_variant_finding.py
@@ -12,8 +12,10 @@ from cluster_vcf_records import variant_tracking, vcf_file_read
 from varifier import global_align, dnadiff, probe_mapping, utils
 
 
-def _check_dependencies_in_path():
-    programs = ["minimap2", "paftools.js", "k8"]
+def _check_dependencies_in_path(minimap2_only=False):
+    programs = ["minimap2"]
+    if not minimap2_only:
+        programs.extend(["paftools.js", "k8"])
     found_all = True
     for program in programs:
         if shutil.which(program) is None:
@@ -152,7 +154,7 @@ def make_truth_vcf(
     global_align_max_coord=float("inf"),
     ignore_non_acgt=True,
 ):
-    _check_dependencies_in_path()
+    _check_dependencies_in_path(minimap2_only=use_global_align)
     os.mkdir(outdir)
     minimap2_vcf = os.path.join(outdir, "00.minimap2.vcf")
     dnadiff_vcf = os.path.join(outdir, "00.dnadiff.vcf")


### PR DESCRIPTION
Skip looking for paftools/k8 if we're doing global align. This is primarily for viridian, where we don't want to have to install k8 (which isn't possible on arm). Viridian uses global align.