### PR TITLE
Bug fix gaps at end of global alignment

### DIFF
--- a/tests/edit_distance_test.py
+++ b/tests/edit_distance_test.py
@@ -13,6 +13,17 @@ def test_needleman_wunsch():
     assert aln2 == expect2
 
 
+def test_needleman_wunsch_penalise_seq2_end_gap():
+    seq1 = "GCTTCTTAGGAGAATGACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    seq2 = "GCTTCTTAGGAGA"
+    aln1, aln2 = edit_distance.needleman_wunsch(seq1, seq2)
+    assert aln1 == seq1
+    assert aln2 == "GCTTCTTAGGAG--------------------------------------A"
+    aln1, aln2 = edit_distance.needleman_wunsch(seq1, seq2, penalise_seq2_end_gap=False)
+    assert aln1 == seq1
+    assert aln2 == "GCTTCTTAGGAGA--------------------------------------"
+
+
 def test_edit_distance_from_aln_strings():
     assert edit_distance.edit_distance_from_aln_strings("A", "A") == 0
     assert edit_distance.edit_distance_from_aln_strings("A", "C") == 1

--- a/varifier/edit_distance.py
+++ b/varifier/edit_distance.py
@@ -1,11 +1,25 @@
 from Bio import pairwise2
 
 
-def needleman_wunsch(seq1, seq2, match=1, mismatch=-1, gap_open=-5, gap_extend=-3):
+def needleman_wunsch(
+    seq1,
+    seq2,
+    match=1,
+    mismatch=-1,
+    gap_open=-5,
+    gap_extend=-3,
+    penalise_seq2_end_gap=True,
+):
     """Returns global alignment strings from NM alignment of the
     two sequences. Dashes for gaps"""
     alignments = pairwise2.align.globalms(
-        seq1, seq2, match, mismatch, gap_open, gap_extend
+        seq1,
+        seq2,
+        match,
+        mismatch,
+        gap_open,
+        gap_extend,
+        penalize_end_gaps=(True, penalise_seq2_end_gap),
     )
     assert len(alignments[0][0]) == len(alignments[0][1])
     return alignments[0][0], alignments[0][1]

--- a/varifier/global_align.py
+++ b/varifier/global_align.py
@@ -169,10 +169,11 @@ def global_align(
         # not penalise gaps at the end of the query, and then we get this:
         # ref: GCTTCTTAGGAGAATGACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
         # qry: GCTTCTTAGGAGA--------------------------------------
+        penalise_end = i < len(matches) - 1
         ref_aln, qry_aln = edit_distance.needleman_wunsch(
             ref_seq[match["ref_end"] + 1 : ref_end],
             qry_seq[match["qry_end"] + 1 : qry_end],
-            penalise_seq2_end_gap=False,
+            penalise_seq2_end_gap=penalise_end,
         )
         aln_ref_seq.extend(list(ref_aln))
         aln_qry_seq.extend(list(qry_aln))

--- a/varifier/global_align.py
+++ b/varifier/global_align.py
@@ -161,9 +161,18 @@ def global_align(
             ref_end = len(ref_seq)
             qry_end = len(qry_seq)
 
+        # When we're aligning the end of the genomes, we don't want to do
+        # proper global align because can end up with something like this:
+        # ref: GCTTCTTAGGAGAATGACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        # qry: GCTTCTTAGGAG--------------------------------------A
+        # Using penalise_seq2_end_gap=False means it does an alignment that does
+        # not penalise gaps at the end of the query, and then we get this:
+        # ref: GCTTCTTAGGAGAATGACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        # qry: GCTTCTTAGGAGA--------------------------------------
         ref_aln, qry_aln = edit_distance.needleman_wunsch(
             ref_seq[match["ref_end"] + 1 : ref_end],
             qry_seq[match["qry_end"] + 1 : qry_end],
+            penalise_seq2_end_gap=False,
         )
         aln_ref_seq.extend(list(ref_aln))
         aln_qry_seq.extend(list(qry_aln))
@@ -249,7 +258,11 @@ def variants_from_global_alignment(ref_aln, qry_aln, ignore_non_acgt=True):
 def expand_combined_snps(variants_in):
     variants_out = []
     for variant in variants_in:
-        if len(variant["ref_allele"]) == len(variant["qry_allele"]) and "N" not in variant["ref_allele"] and "N" not in variant["qry_allele"]:
+        if (
+            len(variant["ref_allele"]) == len(variant["qry_allele"])
+            and "N" not in variant["ref_allele"]
+            and "N" not in variant["qry_allele"]
+        ):
             for i in range(len(variant["ref_allele"])):
                 variants_out.append(
                     {
@@ -293,7 +306,9 @@ def vcf_using_global_alignment(
         with open(fixed_query_fasta, "w") as f:
             print(seq, file=f)
 
-    variants = variants_from_global_alignment(ref_aln, qry_aln, ignore_non_acgt=ignore_non_acgt)
+    variants = variants_from_global_alignment(
+        ref_aln, qry_aln, ignore_non_acgt=ignore_non_acgt
+    )
     variants = expand_combined_snps(variants)
     ref_seq = utils.load_one_seq_fasta_file(ref_fasta)
     ref_name = ref_seq.id.split()[0]


### PR DESCRIPTION
Global align could end like this real covid example:
```
GCTTCTTAGGAGAATGACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
GCTTCTTAGGAG--------------------------------------A
```
This fixes it so that the result is:
```
GCTTCTTAGGAGAATGACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
GCTTCTTAGGAGA--------------------------------------
```